### PR TITLE
Fix critical bug: Add missing minimap DOM elements to viewer.html

### DIFF
--- a/viewer.html
+++ b/viewer.html
@@ -85,6 +85,10 @@
     <div id="content" class="collapsed">
       <div id="diagram" aria-live="polite">
         <div id="canvas"></div>
+        <div id="minimap">
+          <div id="mm-content"></div>
+          <div id="mm-viewport"></div>
+        </div>
       </div>
       <div id="divider" role="separator" aria-orientation="vertical" aria-label="Resize editor"></div>
       <div id="codeWrap" class="code-wrap">


### PR DESCRIPTION
CRITICAL FIX: The JavaScript code referenced three minimap elements (#minimap, #mm-content, #mm-viewport) that were missing from the HTML, causing runtime null reference errors in functions like updateMinimap(), onMinimapDown(), and onMinimapMove().

Added the required minimap structure inside the #diagram element:
- #minimap: Container positioned in bottom-right corner
- #mm-content: Holds the cloned SVG for minimap display
- #mm-viewport: Shows the current viewport rectangle indicator

This fix resolves crashes when users interact with diagram pan/zoom features that depend on the minimap functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)